### PR TITLE
Added alternate url for when using Docker Toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ docker run -ti -p 22449:80 -p 22448:22448 mrsmkl/webasm-test-docker:latest
 ```
 
 Then with a web browser, go to `localhost:22449`. You can post a task and see if the binary search works.
+
+If you are using Docker Toolbox and can't connect try: `http://192.168.99.100:22449/`


### PR DESCRIPTION
I was having trouble accessing the web page because I am a docker noob, so I added what worked for me after getting help from mrsmkl.